### PR TITLE
Fix indent in destroy_all.rb

### DIFF
--- a/destroy_all.rb
+++ b/destroy_all.rb
@@ -1,6 +1,6 @@
 require 'chef/provisioning'
 
 machine_batch do
-    machines search(:node, '*:*').map { |n| n.name }
-      action :destroy
+  machines search(:node, '*:*').map { |n| n.name }
+  action :destroy
 end


### PR DESCRIPTION
Just a little quick fix to indentation.