### PR TITLE
[WIP] Initial push for floating ips in testing-stack.

### DIFF
--- a/environments/vagrant-multi-nova.json
+++ b/environments/vagrant-multi-nova.json
@@ -67,15 +67,20 @@
                 "network": {
                     "public_interface": "eth0",
                     "service_type": "nova",
-                    "multi_host": "true"
+                    "multi_host": "true",
+                    "floating": true,
+                    "auto_assign_floating_ip": true
+                    "floating": {
+                        "ipv4_cidr": "172.16.100.0/24"
+                    },
                 },
                 "config": {
                     "ram_allocation_ratio": 5.0
                 },
                 "networks": [
                     {
-                        "label": "public",
-                        "ipv4_cidr": "172.16.100.0/24",
+                        "label": "internal",
+                        "ipv4_cidr": "10.0.0.0/24",
                         "num_networks": "1",
                         "network_size": "254",
                         "bridge": "br100",


### PR DESCRIPTION
This PR will enable floating ips instead of putting it directly on the network.

This seems like a much better idea, so we can have a "standard" privatized network and you'll only have to change one option for the public side.