### PR TITLE
Workaround until ceph cookbook is uploaded to supermarket

### DIFF
--- a/.chef/knife.rb
+++ b/.chef/knife.rb
@@ -12,3 +12,4 @@ chef_server_url 'https://api.opscode.com/organizations/my_awesome_org'
 cache_type 'BasicFile'
 cache_options(path: "#{ENV['HOME']}/.chef/checksums")
 cookbook_path ["#{current_dir}/../cookbooks"]
+knife[:secret_file] = "#{current_dir}/encrypted_data_bag_secret"

--- a/Berksfile
+++ b/Berksfile
@@ -4,7 +4,7 @@ cookbook 'apache2', '3.0.0'
 cookbook 'apt', '2.6.1'
 cookbook 'aws', '2.1.1'
 cookbook 'build-essential', '1.4.2'
-cookbook 'database', '2.2.0'
+#cookbook 'database', '2.2.0'
 cookbook 'erlang', '1.4.2'
 cookbook 'memcached', '1.7.2'
 cookbook 'mysql'
@@ -18,6 +18,7 @@ cookbook 'yum', '3.5.2'
 cookbook 'selinux', '0.7.2'
 cookbook 'yum-epel', '0.6.0'
 cookbook 'statsd', github: 'att-cloud/cookbook-statsd'
+cookbook "ceph", github: "ceph/ceph-cookbook", branch: "master"
 
 cookbook 'openstack-block-storage', github: 'stackforge/cookbook-openstack-block-storage', branch: "master"
 cookbook 'openstack-common', github: 'stackforge/cookbook-openstack-common', branch: "master"


### PR DESCRIPTION
When I do this locally, I am able to `chef exec rake berks_vendor`.  However, trying to run `chef exec rake aio_nova` fails with the following output from within chef-provisioning (trying to provision the `controller` machine):

```
[2015-02-18T00:32:00+00:00] INFO: Loading encrypted databag user_passwords.mysqlroot using key at /etc/chef/openstack_data_bag_secret
[2015-02-18T00:32:00+00:00] INFO: HTTP Request Returned 404 Not Found : Object not found: http://localhost:8889/data/user_passwords/mysqlroot

================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/openstack-ops-database/recipes/server.rb
================================================================================

Net::HTTPServerException
------------------------
404 "Not Found "

Cookbook Trace:
---------------
 /var/chef/cache/cookbooks/openstack-common/libraries/passwords.rb:72:in `encrypted_secret'
 /var/chef/cache/cookbooks/openstack-common/libraries/passwords.rb:57:in `secret'
 /var/chef/cache/cookbooks/openstack-common/libraries/passwords.rb:121:in `get_password'
 /var/chef/cache/cookbooks/openstack-ops-database/recipes/mysql-server.rb:29:in `from_file'
 /var/chef/cache/cookbooks/openstack-ops-database/recipes/server.rb:22:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/openstack-common/libraries/passwords.rb:

65:      end
66:    end
67:
68:    def encrypted_secret(bag_name, index)
69:      key_path = node['openstack']['secret']['key_path']
70:      ::Chef::Log.info "Loading encrypted databag #{bag_name}.#{index} using key at #{key_path}"
71:      secret = ::Chef::EncryptedDataBagItem.load_secret key_path
72>>     ::Chef::EncryptedDataBagItem.load(bag_name, index, secret)[index]
73:    end
74:
75:    def standard_secret(bag_name, index)
76:      ::Chef::Log.info "Loading databag #{bag_name}.#{index}"
77:      ::Chef::DataBagItem.load(bag_name, index)[index]
78:    end
79:
80:    def vault_secret(bag_name, index)
81:      begin


Running handlers:
[2015-02-18T00:32:00+00:00] ERROR: Running exception handlers
Running handlers complete
[2015-02-18T00:32:00+00:00] ERROR: Exception handlers complete
[2015-02-18T00:32:00+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
Chef Client failed. 0 resources updated in 58.986333308 seconds
[2015-02-18T00:32:00+00:00] ERROR: 404 "Not Found "
[2015-02-18T00:32:00+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```